### PR TITLE
Don't use SSLv3 method

### DIFF
--- a/src/canl_ocsp.c
+++ b/src/canl_ocsp.c
@@ -355,7 +355,7 @@ send_request(OCSP_REQUEST *req, char *host, char *path,  int port, int ssl,
     if (ssl){
         BIO *sbio;
         /*TODO what method to use? default is SSLv3 for now*/
-        ctx_in = SSL_CTX_new(SSLv3_client_method());
+        ctx_in = SSL_CTX_new(SSLv23_client_method());
         if (ctx_in == NULL) {
             goto end;
         }


### PR DESCRIPTION
The new version of openssl in Debian has been compiled without ssl3 support. This means that the SSLv3_client_method function no longer is available. For this reason the compilation of canl-c fails:

https://buildd.debian.org/status/package.php?p=canl-c

undefined reference to `SSLv3_client_method'

I don't know what is the best way to fix this. One way is to use SSLv23_client_method instead, as in this pull request. But you might have other ideas.
