### PR TITLE
Fix spelling of enough

### DIFF
--- a/src/canl_cert.c
+++ b/src/canl_cert.c
@@ -66,7 +66,7 @@ int do_set_ctx_own_cert_file(glb_ctx *cc, mech_glb_ctx *m_ctx,
         m_ctx->cert_key = (cert_key_store *) calloc(1, 
                 sizeof(*(m_ctx->cert_key)));
         if (!m_ctx->cert_key) {
-            return set_error(cc, ENOMEM, POSIX_ERROR, "not enought memory"
+            return set_error(cc, ENOMEM, POSIX_ERROR, "not enough memory"
                     " for the certificate storage"); 
         }
     }

--- a/src/canl_cred.c
+++ b/src/canl_cred.c
@@ -128,7 +128,7 @@ canl_ctx_set_cred(canl_ctx ctx, canl_cred cred)
         m_ctx->cert_key = (cert_key_store *) calloc(1, 
                 sizeof(*(m_ctx->cert_key)));
         if (!m_ctx->cert_key) {
-            return set_error(cc, ENOMEM, POSIX_ERROR, "not enought memory"
+            return set_error(cc, ENOMEM, POSIX_ERROR, "not enough memory"
                     " for the certificate storage");
         }
     }


### PR DESCRIPTION
Found by lintian (tagged as spelling-error-in-binary).
