### PR TITLE
Add missing dependencies to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,11 @@ ${LIBCANL}:\
 #	${LEX} -t $< > $@
 	cp `echo $< | sed -e 's/\.l$$/.c.in/'` $@
 
+namespaces_lex.c: namespaces_parse.h
+signing_policy_lex.c: signing_policy_parse.h
+namespaces_parse.h: namespaces_parse.c
+signing_policy_parse.h: signing_policy_parse.c
+
 %.lo: %.c ${HEAD_CANL} 
 	${COMPILE} -c $< ${CFLAGS_LIB} -o $@
 


### PR DESCRIPTION
The *_parse.h headers must be created before the *_lex.c sources are compiled. Otherwise the compilation fails due to missing headers.
```
./src/proxy/signing_policy_lex.l:33:10: fatal error: signing_policy_parse.h: No such file or directory
   33 | #include "signing_policy_parse.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.

./src/proxy/namespaces_lex.l:33:10: fatal error: namespaces_parse.h: No such file or directory
   33 | #include "namespaces_parse.h"
      |          ^~~~~~~~~~~~~~~~~~~~
compilation terminated.
```
