### PR TITLE
Fix compilation with GCC 15

### DIFF
--- a/src/proxy/sslutils.h
+++ b/src/proxy/sslutils.h
@@ -398,7 +398,7 @@ int proxy_load_user_cert_and_key_pkcs12(const char *user_cert,
                                         X509 **cert,
                                         STACK_OF(X509) **stack,
                                         EVP_PKEY **pkey,
-                                        int (*pw_cb) ());
+                                        pem_password_cb *pw_cb);
 
 int
 proxy_get_filenames(
@@ -413,7 +413,7 @@ int
 proxy_load_user_cert(
     const char *                        user_cert,
     X509 **                             certificate,
-    int                                 (*pw_cb)(),
+    pem_password_cb *                   pw_cb,
     unsigned long *                     hSession);
 
 int
@@ -421,7 +421,7 @@ proxy_load_user_key(
     EVP_PKEY **                         private_key,
     X509 * ucert,
     const char *                        user_key,
-    int                                 (*pw_cb)(),
+    pem_password_cb *                   pw_cb,
     unsigned long *                     hSession);
 
 void
@@ -467,7 +467,7 @@ proxy_genreq(
     EVP_PKEY **                         pkeyp,
     int                                 bits,
     const char *                        newdn,
-    int                                 (*callback)());
+    void                                (*callback)(int, int, void *));
 
 int
 proxy_sign(
@@ -557,8 +557,8 @@ time_t ASN1_TIME_mktime(ASN1_TIME *ctm);
 int PRIVATE determine_filenames(char **cacert, char **certdir, char **outfile,
                                 char **certfile, char **keyfile, int noregen);
 int load_credentials(const char *certname, const char *keyname,
-                             X509 **cert, STACK_OF(X509) **stack, EVP_PKEY **key,
-                             int (*callback)());
+                     X509 **cert, STACK_OF(X509) **stack, EVP_PKEY **key,
+                     pem_password_cb *callback);
 int PRIVATE load_certificate_from_file(FILE *file, X509 **cert, 
                                        STACK_OF(X509) **stack);
 


### PR DESCRIPTION
GCC 15 has improved diagnostics and detects more incompatible pointer type errors than earlier versions. Especially function pointers being assigned pointers to function with the wrong type and/or number of arguments are better detected.

This commit fixes the compilation with GCC 15.